### PR TITLE
Fix/smtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ gitlab_rails_smtp_enable_starttls_auto: yes
 gitlab_rails_smtp_tls: no
 gitlab_rails_smtp_pool: no
 gitlab_rails_smtp_openssl_verify_mode: none
-gitlab_rails_smtp_ca_path: etc/ssl/certs
+gitlab_rails_smtp_ca_path: /etc/ssl/certs
 gitlab_rails_smtp_ca_file: /etc/ssl/certs/ca-certificates.crt
 
 # E-mail settings.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,7 +163,7 @@ gitlab_rails_smtp_enable_starttls_auto: yes
 gitlab_rails_smtp_tls: no
 gitlab_rails_smtp_pool: no
 gitlab_rails_smtp_openssl_verify_mode: none
-gitlab_rails_smtp_ca_path: etc/ssl/certs
+gitlab_rails_smtp_ca_path: /etc/ssl/certs
 gitlab_rails_smtp_ca_file: /etc/ssl/certs/ca-certificates.crt
 
 # E-mail settings.

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -81,23 +81,25 @@ roles [{% for role in gitlab_roles %}'{{ role }}'{{ ", " if not loop.last }}{% e
 ###! Docs: https://docs.gitlab.com/omnibus/settings/smtp.html
 ###! **Use smtp instead of sendmail/postfix.**
 
-# gitlab_rails['smtp_enable'] = true
-# gitlab_rails['smtp_address'] = "smtp.server"
-# gitlab_rails['smtp_port'] = 465
-# gitlab_rails['smtp_user_name'] = "smtp user"
-# gitlab_rails['smtp_password'] = "smtp password"
-# gitlab_rails['smtp_domain'] = "example.com"
-# gitlab_rails['smtp_authentication'] = "login"
-# gitlab_rails['smtp_enable_starttls_auto'] = true
-# gitlab_rails['smtp_tls'] = false
-# gitlab_rails['smtp_pool'] = false
+gitlab_rails['smtp_enable'] = {{ gitlab_rails_smtp_enable | string | lower }}
+{% if gitlab_rails_smtp_enable %}
+gitlab_rails['smtp_address'] = "{{ gitlab_rails_smtp_address }}"
+gitlab_rails['smtp_port'] = {{ gitlab_rails_smtp_port | int }}
+gitlab_rails['smtp_user_name'] = "{{ gitlab_rails_smtp_user_name }}"
+gitlab_rails['smtp_password'] = "{{ gitlab_rails_smtp_password }}"
+gitlab_rails['smtp_domain'] = "{{ gitlab_rails_smtp_domain }}"
+gitlab_rails['smtp_authentication'] = "{{ gitlab_rails_smtp_authentication }}"
+gitlab_rails['smtp_enable_starttls_auto'] = {{ gitlab_rails_smtp_enable_starttls_auto | string | lower }}
+gitlab_rails['smtp_tls'] = {{ gitlab_rails_smtp_tls | string | lower }}
+gitlab_rails['smtp_pool'] = {{ gitlab_rails_smtp_pool | string | lower }}
 
 ###! **Can be: 'none', 'peer', 'client_once', 'fail_if_no_peer_cert'**
 ###! Docs: http://api.rubyonrails.org/classes/ActionMailer/Base.html
-# gitlab_rails['smtp_openssl_verify_mode'] = 'none'
+gitlab_rails['smtp_openssl_verify_mode'] = '{{ gitlab_rails_smtp_openssl_verify_mode }}'
 
-# gitlab_rails['smtp_ca_path'] = "/etc/ssl/certs"
-# gitlab_rails['smtp_ca_file'] = "/etc/ssl/certs/ca-certificates.crt"
+gitlab_rails['smtp_ca_path'] = "{{ gitlab_rails_smtp_ca_path }}"
+gitlab_rails['smtp_ca_file'] = "{{ gitlab_rails_smtp_ca_file }}"
+{% endif %}
 
 ### Email Settings
 


### PR DESCRIPTION
See issue #10, fixes small typo in `smtp_ca_path` and enables SMTP settings, following the same schema as with _Email settings_.