### PR TITLE
Add ability to set ACME staging / production endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ gitlab_letsencrypt: yes
 # gitlab_letsencrypt_auto_renew_hour: 0
 # gitlab_letsencrypt_auto_renew_minute: nil
 # gitlab_letsencrypt_auto_renew_day_of_month: nil
-# gitlab_letsencrypy_auto_renew_log_directory: /var/log/gitlab/lets-encrypt
+# gitlab_letsencrypt_auto_renew_log_directory: /var/log/gitlab/lets-encrypt
 
 # In case you need to trust a (CA) certificate to access remote resources,
 # like an LDAP server, download the (CA) certificate, place it in the `files`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -321,7 +321,7 @@ gitlab_rails_db_statements_limit: 1000
 
 # SSL settings
 # # If you do not want to use SSL, use this structure.
-gitlab_letsencrypt: yes
+# gitlab_letsencrypt: no
 # gitlab_external_url: "http://gitlab.example.com" # (No `https` in the value.)
 # # If you bring your own certificates, use this structure.
 # gitlab_letsencrypt: no
@@ -332,6 +332,8 @@ gitlab_letsencrypt: yes
 # gitlab_letsencrypt: yes
 # gitlab_letsencrypt_contact_emails:
 #   - robert@meinit.nl
+# gitlab_acme_staging_endpoint: https://ca.internal/acme/acme/directory
+# gitlab_acme_production_endpoint: https://ca.internal/acme/acme/directory
 # gitlab_letsencrypt_group: root
 # gitlab_letsencrypt_key_size: 2048
 # gitlab_letsencrypt_owner: root
@@ -340,7 +342,7 @@ gitlab_letsencrypt: yes
 # gitlab_letsencrypt_auto_renew_hour: 0
 # gitlab_letsencrypt_auto_renew_minute: nil
 # gitlab_letsencrypt_auto_renew_day_of_month: nil
-# gitlab_letsencrypy_auto_renew_log_directory: /var/log/gitlab/lets-encrypt
+# gitlab_letsencrypt_auto_renew_log_directory: /var/log/gitlab/lets-encrypt
 
 # In case you need to trust a (CA) certificate to access remote resources,
 # like an LDAP server, download the (CA) certificate, place it in the `files`

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -912,7 +912,7 @@
              gitlab_letsencrypt_auto_renew_hour >= 0 and
              gitlab_letsencrypt_auto_renew_hour <= 24) or
             (gitlab_letsencrypt_auto_renew_hour is string and
-            (gitlab_letsencrypt_auto_renew_hour is not none)
+             gitlab_letsencrypt_auto_renew_hour is not none)
         quiet: yes
       when:
         - gitlab_letsencrypt is defined
@@ -927,7 +927,7 @@
              gitlab_letsencrypt_auto_renew_minute >= 0 and
              gitlab_letsencrypt_auto_renew_minute <= 59) or
             (gitlab_letsencrypt_auto_renew_minute is string and
-            (gitlab_letsencrypt_auto_renew_minute is not none)
+             gitlab_letsencrypt_auto_renew_minute is not none)
         quiet: yes
       when:
         - gitlab_letsencrypt is defined
@@ -942,7 +942,7 @@
              gitlab_letsencrypt_auto_renew_day_of_month >= 0 and
              gitlab_letsencrypt_auto_renew_day_of_month <= 31) or
             (gitlab_letsencrypt_auto_renew_day_of_month is string and
-            (gitlab_letsencrypt_auto_renew_day_of_month is not none)
+             gitlab_letsencrypt_auto_renew_day_of_month is not none)
         quiet: yes
       when:
         - gitlab_letsencrypt is defined

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -949,12 +949,12 @@
         - gitlab_letsencrypt
         - gitlab_letsencrypt_auto_renew
 
-    - name: assert | Test gitlab_letsencrypy_auto_renew_log_directory
+    - name: assert | Test gitlab_letsencrypt_auto_renew_log_directory
       ansible.builtin.assert:
         that:
-          - gitlab_letsencrypy_auto_renew_log_directory is defined
-          - gitlab_letsencrypy_auto_renew_log_directory is string
-          - gitlab_letsencrypy_auto_renew_log_directory is not none
+          - gitlab_letsencrypt_auto_renew_log_directory is defined
+          - gitlab_letsencrypt_auto_renew_log_directory is string
+          - gitlab_letsencrypt_auto_renew_log_directory is not none
         quiet: yes
       when:
         - gitlab_letsencrypt is defined

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -2421,7 +2421,9 @@ letsencrypt['auto_renew'] = {{ gitlab_letsencrypt_auto_renew | ternary('true', '
 letsencrypt['auto_renew_hour'] = {{ gitlab_letsencrypt_auto_renew_hour }}
 letsencrypt['auto_renew_minute'] = {{ gitlab_letsencrypt_auto_renew_minute }}
 letsencrypt['auto_renew_day_of_month'] = "{{ gitlab_letsencrypt_auto_renew_day_of_month }}"
-letsencrypt['auto_renew_log_directory'] = '{{ gitlab_letsencrypy_auto_renew_log_directory }}'
+letsencrypt['auto_renew_log_directory'] = '{{ gitlab_letsencrypt_auto_renew_log_directory }}'
+letsencrypt['acme_staging_endpoint'] = '{{ gitlab_acme_staging_endpoint }}'
+letsencrypt['acme_production_endpoint'] = '{{ gitlab_acme_production_endpoint }}'
 {% else %}
 letsencrypt['enable'] = nil
 {% endif %}


### PR DESCRIPTION
This allows you to set the ACME staging and production endpoints rather than using Lets Encrypt.



