### PR TITLE
Always template configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,8 @@ gitlab_distribution: community
 # Would you like Ansible to show you the initial_root_password?
 gitlab_show_initial_root_password: false
 
-# Instead of defining the variables below, you can also simply copy a configuration file.
-# Place this file into the `files` directory that hosts the playbooks.
-# To configure GitLab using variables, comment this line
-# gitlab_configuration_file: gitlab.rb
+# Configuration file template
+gitlab_configuration_file: gitlab.rb.j2
 
 # The configuration below is only required when **not** placing a configuration file.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,10 +16,8 @@ gitlab_distribution: community
 # Would you like Ansible to show you the initial_root_password?
 gitlab_show_initial_root_password: false
 
-# Instead of defining the variables below, you can also simply copy a configuration file.
-# Place this file into the `files` directory that hosts the playbooks.
-# To configure GitLab using variables, comment this line
-# gitlab_configuration_file: gitlab.rb
+# Configuration file template
+gitlab_configuration_file: gitlab.rb.j2
 
 # The configuration below is only required when **not** placing a configuration file.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,9 +115,9 @@
             group: root
             mode: "0640"
 
-- name: Place configuration templated
+- name: Place configuration
   ansible.builtin.template:
-    src: gitlab.rb.j2
+    src: "{{ gitlab_configuration_file }}"
     dest: /etc/gitlab/gitlab.rb
     owner: root
     group: root
@@ -125,8 +125,6 @@
     validate: ruby -c %s
   notify:
     - Run gitlab-ctl reconfigure
-  when:
-    - gitlab_configuration_file is not defined
 
 - name: Place trusted-certs
   when:
@@ -151,20 +149,6 @@
       notify:
         - Run gitlab-ctl reconfigure
       loop: "{{ gitlab_trusted_certs }}"
-
-- name: Place configuration static
-  ansible.builtin.copy:
-    src: "{{ gitlab_configuration_file }}"
-    dest: /etc/gitlab/gitlab.rb
-    owner: root
-    group: root
-    mode: "0600"
-    validate: ruby -c %s
-  notify:
-    - Run gitlab-ctl reconfigure
-  when:
-    - gitlab_configuration_file is defined
-    - gitlab_configuration_file is not none
 
 - name: Show initial root password
   when:


### PR DESCRIPTION
Currently, it's not possible to use a custom template with this role, since the name is hardcoded.

Instead, always template the config file, since it's very little extra overhead. This allows someone to still use a custom template, or reuse the existing one.